### PR TITLE
feat: add context timeout when running migration

### DIFF
--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"os"
+	"time"
 
 	"github.com/gobuffalo/pop/v6"
 	"github.com/gobuffalo/pop/v6/logging"
@@ -78,7 +80,9 @@ func migrate(cmd *cobra.Command, args []string) {
 
 	if globalConfig.DB.AutoCreateNamespace {
 		log.Infof("Create schema if not exists: %s", globalConfig.DB.Namespace)
-		_, err = db.Store.Exec(fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", globalConfig.DB.Namespace))
+		ctx, cancel := context.WithTimeout(context.Background(), time.Duration(time.Second*5))
+		defer cancel()
+		_, err = db.Store.ExecContext(ctx, fmt.Sprintf("CREATE SCHEMA IF NOT EXISTS %s", globalConfig.DB.Namespace))
 		if err != nil {
 			log.Fatalf("%+v", errors.Wrap(err, "creating namespace"))
 		}


### PR DESCRIPTION
Without context timeout, gotrue will get stuck if the connection is open but the database is not ready.